### PR TITLE
Change how vaccine strain is picked and simplify immunity behavior

### DIFF
--- a/rotasim/rotasim_genetics.py
+++ b/rotasim/rotasim_genetics.py
@@ -14,7 +14,7 @@ __all__ = ['Rota']
 
 # Define age bins and labels
 age_bins = [2/12, 4/12, 6/12, 12/12, 24/12, 36/12, 48/12, 60/12, 100]
-age_distribution = [0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.84]                  # needs to be changed to fit the site-specific population
+age_distribution = [0.006, 0.006, 0.006, 0.036, 0.025, 0.025, 0.025, 0.025, 0.846]                  # needs to be changed to fit the site-specific population
 age_labels = ['0-2', '2-4', '4-6', '6-12', '12-24', '24-36', '36-48', '48-60', '60+']
 
 
@@ -319,7 +319,9 @@ class Rota(ss.Module):
         # segmentVariants = [[1,2,3,4,9], [8,4], [i for i in range(1, 2)], [i for i in range(1, 2)]]
 
         self.define_pars(
-            immunity_hypothesis = 1,
+            initial_diversity_setting = 'low',  # low or high
+            num_initial_infected_per_strain = 100,  # number of initial infected per strain
+
             reassortment_rate = 0.1,
             fitness_hypothesis = 2,
             vaccine_hypothesis = 1,
@@ -364,7 +366,7 @@ class Rota(ss.Module):
             contact_rate = 365 / 1,
             reassortmentRate_GP = None,
 
-            vaccination_time = 20, # vaccinations begin at this year in the sim
+            vaccination_time = 15, # vaccinations begin at this year in the sim
 
             # Efficacy of the vaccine first dose
             vaccine_efficacy_d1 = {
@@ -393,6 +395,13 @@ class Rota(ss.Module):
 
             # Time to wait before computing strain counts. Allows the simulation to reach a equilibrium.
             time_to_equilibrium = 5,
+
+            # Natural immunity rates: Relative protection to infection from natural immunity
+            homotypic_immunity_rate = 0.5,
+            partial_heterotypic_immunity_rate = 0.5,
+            complete_heterotypic_immunity_rate = 0.5,
+
+
         )
 
         # update the pars based on the kwargs
@@ -417,9 +426,21 @@ class Rota(ss.Module):
         )
 
         # Set filenames
-        name_suffix = '%r_%r_%r_%r_%r_%r_%r_%r_%r_%r' % (
-        self.pars.immunity_hypothesis, self.pars.reassortment_rate, self.pars.fitness_hypothesis, self.pars.vaccine_hypothesis,
-        self.pars.waning_hypothesis, self.pars.initial_immunity, self.pars.ve_i_to_ve_s_ratio, self.pars.vaccination_single_dose_waning_rate, self.pars.contact_rate, self.pars.experiment_number)
+        name_suffix = ''.join((
+            f"{self.pars.initial_diversity_setting}_",
+            f"{self.pars.homotypic_immunity_rate}_",
+            f"{self.pars.partial_heterotypic_immunity_rate}_"
+            f"{self.pars.complete_heterotypic_immunity_rate}_"
+            f"{self.pars.reassortment_rate}_"
+            f"{self.pars.fitness_hypothesis}_"
+            f"{self.pars.vaccine_hypothesis}_"
+            f"{self.pars.waning_hypothesis}_"
+            f"{self.pars.initial_immunity}_"
+            f"{self.pars.ve_i_to_ve_s_ratio}_"
+            f"{self.pars.vaccination_single_dose_waning_rate}_"
+            f"{self.pars.contact_rate}_"
+            f"{self.pars.experiment_number}"
+        ))
         self.files = sc.objdict()
         self.files.outputfilename = './results/rota_strain_count_%s.csv' % (name_suffix)
         self.files.vaccinations_outputfilename = './results/rota_vaccinecount_%s.csv' % (name_suffix)
@@ -475,34 +496,10 @@ class Rota(ss.Module):
             infected_all=[],
         )
 
-        # relative protection for infection from natural immunity
-        immunity_hypothesis = self.pars.immunity_hypothesis
-
-        # Define the mapping of immunity_hypothesis to their corresponding rates using tuples
-        immunity_rates = {
-            1: (0, 0, 0),
-            2: (0, 1, 0),
-            3: (0, 0.5, 0),
-            4: (0, 0.95, 0.9),
-            5: (0, 0.95, 0.90),
-            7: (0.95, 0.90, 0.2),
-            8: (0.9, 0.5, 0),
-            9: (0.9, 0.45, 0.35),
-            10: (0.8, 0.45, 0.35),
-        }
-
-        # Get the rates for the given immunity_hypothesis
-        rates = immunity_rates.get(immunity_hypothesis)
-
-        if rates is None:
-            raise NotImplementedError(f"No partial cross immunity rate for immunity hypothesis: {immunity_hypothesis}")
-
         # Unpack the tuple into the corresponding variables
-        homotypic_immunity_rate, partial_cross_immunity_rate, complete_heterotypic_immunity_rate = rates
-
-        self.homotypic_immunity_rate = homotypic_immunity_rate
-        self.partial_cross_immunity_rate = partial_cross_immunity_rate
-        self.complete_heterotypic_immunity_rate = complete_heterotypic_immunity_rate
+        self.homotypic_immunity_rate = self.pars.homotypic_immunity_rate
+        self.partial_heterotypic_immunity_rate = self.pars.partial_heterotypic_immunity_rate
+        self.complete_heterotypic_immunity_rate = self.pars.complete_heterotypic_immunity_rate
 
         self.done_vaccinated = False
 
@@ -535,27 +532,32 @@ class Rota(ss.Module):
 
         rnd.shuffle(self.pars.segment_combinations)
         number_all_strains = len(self.pars.segment_combinations)
-        n_init_seg = 100
-        initial_segment_combinations = {
-            (1, 8, 1, 1): n_init_seg,
-            (2, 4, 1, 1): n_init_seg,
-            (9, 8, 1, 1): n_init_seg,
-            (4, 8, 1, 1): n_init_seg,
-            (3, 8, 1, 1): n_init_seg,
-            (12, 8, 1, 1): n_init_seg,
-            (12, 6, 1, 1): n_init_seg,
-            (9, 4, 1, 1): n_init_seg,
-            (9, 6, 1, 1): n_init_seg,
-            (1, 6, 1, 1): n_init_seg,
-            (2, 8, 1, 1): n_init_seg,
-            (2, 6, 1, 1): n_init_seg,
-            (11, 8, 1, 1): n_init_seg,
-            (11, 6, 1, 1): n_init_seg,
-            (1, 4, 1, 1): n_init_seg,
-            (12, 4, 1, 1): n_init_seg,
-        }
-        # initial strains for the Low baseline diversity setting
-        # initial_segment_combinations = {(1,8,1,1): 100, (2,4,1,1): 100} #, (9,8,1,1): 100} #, (4,8,1,1): 100}
+        n_init_seg = self.pars.num_initial_infected_per_strain
+        
+        if self.pars.initial_diversity_setting == 'high':
+            initial_segment_combinations = {
+                (1, 8, 1, 1): n_init_seg,
+                (2, 4, 1, 1): n_init_seg,
+                (9, 8, 1, 1): n_init_seg,
+                (4, 8, 1, 1): n_init_seg,
+                (3, 8, 1, 1): n_init_seg,
+                (12, 8, 1, 1): n_init_seg,
+                (12, 6, 1, 1): n_init_seg,
+                (9, 4, 1, 1): n_init_seg,
+                (9, 6, 1, 1): n_init_seg,
+                (1, 6, 1, 1): n_init_seg,
+                (2, 8, 1, 1): n_init_seg,
+                (2, 6, 1, 1): n_init_seg,
+                (11, 8, 1, 1): n_init_seg,
+                (11, 6, 1, 1): n_init_seg,
+                (1, 4, 1, 1): n_init_seg,
+                (12, 4, 1, 1): n_init_seg,
+            }
+        elif self.pars.initial_diversity_setting == 'low':
+            # initial strains for the Low baseline diversity setting
+            initial_segment_combinations = {(1,8,1,1): n_init_seg, (3,8,1,1): n_init_seg, (2,4,1,1): n_init_seg, (4,8,1,1): n_init_seg}
+        else:
+            raise ValueError("Invalid initial_diversity_setting: %s" % self.pars.initial_diversity_setting)
 
         # Track the number of immune hosts(immunity_counts) in the host population
         infected_uids = []
@@ -619,6 +621,7 @@ class Rota(ss.Module):
             write = csv.writer(outputfile)
             write.writerow(["time"] + list(self.strain_count.keys()) + ["reassortment_count"])  # header for the csv file
             write.writerow([self.t.abstvec[self.ti]] + list(self.strain_count.values()) + [self.reassortment_count])  # first row of the csv file will be the initial state
+        self.reassortment_count = 0
 
         with open(files.sample_outputfilename, "w+", newline='') as outputfile:
             write = csv.writer(outputfile)
@@ -947,7 +950,7 @@ class Rota(ss.Module):
         for reassortment_host in reassortment_hosts:
             parentalstrains = [path.strain for path in self.infecting_pathogen[reassortment_host]]
             possible_reassortants = [path for path in self.compute_combinations(reassortment_host) if
-                                     path not in parentalstrains]
+                                     path.strain not in parentalstrains]
             for path in possible_reassortants:
                 self.infect_with_reassortant(reassortment_host, path)
 
@@ -1260,8 +1263,7 @@ class Rota(ss.Module):
     def can_variant_infect_host(self, uid, infecting_strain):
         current_infections = self.infecting_pathogen[uid]
         numAgSegments = self.pars.numAgSegments
-        immunity_hypothesis = self.pars.immunity_hypothesis
-        partial_cross_immunity_rate = self.partial_cross_immunity_rate
+        partial_heterotypic_immunity_rate = self.partial_heterotypic_immunity_rate
         complete_heterotypic_immunity_rate = self.complete_heterotypic_immunity_rate
         homotypic_immunity_rate = self.homotypic_immunity_rate
 
@@ -1272,54 +1274,25 @@ class Rota(ss.Module):
         if infecting_strain[:numAgSegments] in current_infecting_strains:
             return False
 
-        def is_completely_immune():
+        def is_complete_antigenic_match():
             immune_strains = (s[:numAgSegments] for s in self.immunity[uid].keys())
             return infecting_strain[:numAgSegments] in immune_strains
 
-        def has_shared_genotype():
+        def has_shared_antigenic_genotype():
             for i in range(numAgSegments):
                 immune_genotypes = (strain[i] for strain in self.immunity[uid].keys())
                 if infecting_strain[i] in immune_genotypes:
                     return True
             return False
 
+        if is_complete_antigenic_match():
+            return rnd.random() > homotypic_immunity_rate
 
-        if immunity_hypothesis == 1:
-            if is_completely_immune():
-                return False
-            return True
-
-        elif immunity_hypothesis == 2:
-            if has_shared_genotype():
-                return False
-            return True
-
-        elif immunity_hypothesis in [3, 4, 7, 8, 9, 10]:
-            if is_completely_immune():
-                if immunity_hypothesis in [7, 8, 9, 10]:
-                    if rnd.random() < homotypic_immunity_rate:
-                        return False
-                else:
-                    return False
-
-            if has_shared_genotype():
-                if rnd.random() < partial_cross_immunity_rate:
-                    return False
-            elif immunity_hypothesis in [4, 7, 8, 9, 10]:
-                if rnd.random() < complete_heterotypic_immunity_rate:
-                    return False
-            return True
-
-        elif immunity_hypothesis == 5:
-            immune_ptypes = (strain[1] for strain in self.immunity.keys())
-            return infecting_strain[1] not in immune_ptypes
-
-        elif immunity_hypothesis == 6:
-            immune_ptypes = (strain[0] for strain in self.immunity.keys())
-            return infecting_strain[0] not in immune_ptypes
-
-        else:
-            raise NotImplementedError(f"Immunity hypothesis {immunity_hypothesis} is not implemented")
+        if has_shared_antigenic_genotype():
+            return rnd.random() > partial_heterotypic_immunity_rate
+        
+        # If the strain is complete heterotypic
+        return rnd.random() > complete_heterotypic_immunity_rate
 
     def infect_with_pathogen(self, uid, pathogen_in):
         """ This function returns a fitness value to a strain based on the hypothesis """
@@ -1335,6 +1308,9 @@ class Rota(ss.Module):
             severe = True
         else:
             severe = False
+
+        if pathogen_in.is_reassortant:
+            self.reassortment_count += 1
 
         new_p = RotaPathogen(rotasim=self, is_reassortant=False, creation_time=self.t.abstvec[self.ti], host_uid=uid, strain=pathogen_in.strain, is_severe=severe)
         self.infecting_pathogen[uid].append(new_p)

--- a/tests/test_events_alt.json
+++ b/tests/test_events_alt.json
@@ -1,10 +1,10 @@
 {
-  "births": 596,
-  "deaths": 321,
-  "recoveries": 342883,
-  "contacts": 2402577,
-  "wanings": 226066,
-  "reassortments": 1260,
+  "births": 649,
+  "deaths": 301,
+  "recoveries": 358319,
+  "contacts": 2506808,
+  "wanings": 136215,
+  "reassortments": 1403,
   "vaccine_dose_1_wanings": 0,
   "vaccine_dose_2_wanings": 0
 }

--- a/tests/test_events_default.json
+++ b/tests/test_events_default.json
@@ -1,10 +1,10 @@
 {
-  "births": 642,
-  "deaths": 330,
-  "recoveries": 27007,
-  "contacts": 188436,
-  "wanings": 23110,
-  "reassortments": 39,
+  "births": 650,
+  "deaths": 324,
+  "recoveries": 98892,
+  "contacts": 697704,
+  "wanings": 25560,
+  "reassortments": 198,
   "vaccine_dose_1_wanings": 0,
   "vaccine_dose_2_wanings": 0
 }

--- a/tests/test_rotasim.py
+++ b/tests/test_rotasim.py
@@ -41,7 +41,6 @@ def test_alt(make=False):
     filename = 'test_events_alt.json'
 
     rota_inputs = dict(
-        immunity_hypothesis = 2,
         reassortment_rate = 0.2,
         fitness_hypothesis = 2,
         vaccine_hypothesis = 2,


### PR DESCRIPTION
we used the most prominent strain before vaccination as the vaccine strain. previously we were including the initial non-equilibrium state in this computation. As the beginning of the simulation is unstable (high peaks) this can cause we should not consider it when determining strain proportions. 