### PR TITLE
Scripts for calibration targets

### DIFF
--- a/rotasim/analyzers.py
+++ b/rotasim/analyzers.py
@@ -1,24 +1,45 @@
 import starsim as ss
 import rotasim as rs
 
+
 class StrainStats(ss.Analyzer):
     """
     Analyzer to track the proportions of different strains in the population
     """
+
     def __init__(self):
         super().__init__()
         return
 
-
     def init_results(self):
         super().init_results()
-
+        self.results += ss.Result(
+            "time",
+            dtype=float,
+            scale=False,
+            module=self.name,
+            shape=self.timevec.shape,
+            timevec=self.timevec,
+        )
         for strain in self.sim.connectors.rota.pars.segment_combinations:
-            self.results += ss.Result(f'{strain} proportion', dtype=float, scale=False, module=self.name, shape=self.timevec.shape, timevec=self.timevec)
-            self.results += ss.Result(f'{strain} count', dtype=float, scale=False,
-                                      module=self.name, shape=self.timevec.shape, timevec=self.timevec)
-        return
+            self.results += ss.Result(
+                f"{strain} proportion",
+                dtype=float,
+                scale=False,
+                module=self.name,
+                shape=self.timevec.shape,
+                timevec=self.timevec,
+            )
+            self.results += ss.Result(
+                f"{strain} count",
+                dtype=float,
+                scale=False,
+                module=self.name,
+                shape=self.timevec.shape,
+                timevec=self.timevec,
+            )
 
+        return
 
     def step(self):
         sim = self.sim
@@ -26,21 +47,37 @@ class StrainStats(ss.Analyzer):
         strain_count = sim.connectors.rota.strain_count
 
         # get the list of strains that appeared in the entire simulation
-
         total_count = sum(strain_count.values())
         if total_count:
             for strain in strain_count:
                 # Calculate the proportion of the strain in the population
-                res[f'{strain} proportion'][sim.ti] = strain_count[strain] / total_count
-                res[f'{strain} count'][sim.ti] = strain_count[strain]
-
+                res[f"{strain} proportion"][sim.ti] = strain_count[strain] / total_count
+                res[f"{strain} count"][sim.ti] = strain_count[strain]
+                res["time"][sim.ti] = sim.t.abstvec[sim.ti]
         return
 
     def to_df(self):
         df = self.results.to_df()
 
         # get the list of extra timevec column indexes and drop all but the first
-        indexes_to_drop = df.columns.get_indexer_for(['timevec'])
+        indexes_to_drop = df.columns.get_indexer_for(["timevec"])
         df.drop(columns=df.columns[indexes_to_drop[1:]], inplace=True)
 
         return df
+
+    def get_strain_proportions(self, strain):
+        """
+        Returns a DataFrame with the strain proportions over time.
+        """
+        df = self.to_df()
+
+        # Round time to integers for grouping
+        df["time_rounded"] = df["time"].round().astype(int)
+
+        # Group by rounded time and get mean proportion for the strain
+        strain_proportions = (
+            df.groupby("time_rounded")[f"{strain} proportion"].mean().reset_index()
+        )
+        strain_proportions.rename(columns={"time_rounded": "time"}, inplace=True)
+
+        return strain_proportions

--- a/scripts/get_age_distribution_severe.py
+++ b/scripts/get_age_distribution_severe.py
@@ -1,0 +1,64 @@
+import argparse
+import re
+import pandas as pd
+
+
+def strainName(strainIn):
+    s_types = [set() for i in range(4)]
+    for strain in strainIn:
+        pattern = r"G(\d+)P(\d+)A(\d+)B(\d+)"
+        match = re.match(pattern, strain)
+        for i, n in enumerate(match.groups()):
+            s_types[i].add(n)
+    newLabel = ""
+    for i, l in enumerate("GPRC"):
+        if len(s_types[i]) > 1:
+            newLabel += l + "[" + "+".join(sorted(s_types[i])) + "]"
+        else:
+            newLabel += l + list(s_types[i])[0]
+    return newLabel
+
+
+parser = argparse.ArgumentParser(description="Process input parameters.")
+
+parser.add_argument("datafile", type=str, help="Strain count file")
+args = parser.parse_args()
+
+datafile = args.datafile
+
+print("Processing file: {}".format(datafile))
+df = pd.read_csv(datafile)[
+    [
+        "id",
+        "CollectionTime",
+        "Age",
+        "Strain",
+        "Severity",
+        "InfectionTime",
+        "PopulationSize",
+    ]
+]
+
+df["InfectionTime"] = df["InfectionTime"].astype(int)
+df["Time"] = df["InfectionTime"]
+df["PopulationSize"] = df.groupby(["Time"])["PopulationSize"].transform("min")
+df["PopulationSize"] = df.groupby(["id", "Strain", "Time"])["PopulationSize"].transform(
+    "min"
+)
+
+df = (
+    df.groupby(["id", "Time", "Age", "PopulationSize"])
+    .agg({"Strain": strainName, "Severity": any})
+    .reset_index()
+)
+
+df = df[df["Severity"]]
+
+age_distribution = df.groupby(["Time", "Age"]).size().reset_index(name="Counts")
+
+age_distribution["Percentage"] = age_distribution.groupby(["Time"])["Counts"].transform(
+    lambda x: x / x.sum() * 100
+)
+
+print("Age distribution by time:")
+print(age_distribution.to_string(index=False))

--- a/scripts/get_g1p8_propotion.py
+++ b/scripts/get_g1p8_propotion.py
@@ -1,0 +1,85 @@
+import argparse
+import re
+import pandas as pd
+
+
+def strainName(strainIn):
+    s_types = [set() for i in range(4)]
+    for strain in strainIn:
+        pattern = r"G(\d+)P(\d+)A(\d+)B(\d+)"
+        match = re.match(pattern, strain)
+        for i, n in enumerate(match.groups()):
+            s_types[i].add(n)
+    newLabel = ""
+    for i, l in enumerate("GPRC"):
+        if len(s_types[i]) > 1:
+            newLabel += l + "[" + "+".join(sorted(s_types[i])) + "]"
+        else:
+            newLabel += l + list(s_types[i])[0]
+    return newLabel
+
+
+parser = argparse.ArgumentParser(description="Process input parameters.")
+
+parser.add_argument("datafile", type=str, help="Strain count file")
+parser.add_argument(
+    "--below5", action="store_true", help="use only incidences with age below 5"
+)
+parser.add_argument("--severe", action="store_true", help="use only severe incidences")
+args = parser.parse_args()
+
+datafile = args.datafile
+
+print("Processing file: {}".format(datafile))
+df = pd.read_csv(datafile)[
+    [
+        "id",
+        "CollectionTime",
+        "Age",
+        "Strain",
+        "Severity",
+        "InfectionTime",
+        "PopulationSize",
+    ]
+]
+
+df["InfectionTime"] = df["InfectionTime"].astype(int)
+df["Time"] = df["InfectionTime"]
+df["PopulationSize"] = df.groupby(["Time"])["PopulationSize"].transform("min")
+df["PopulationSize"] = df.groupby(["id", "Strain", "Time"])["PopulationSize"].transform(
+    "min"
+)
+
+df = (
+    df.groupby(["id", "Time", "Age", "PopulationSize"])
+    .agg({"Strain": strainName, "Severity": any})
+    .reset_index()
+)
+
+if args.severe:
+    df = df[df["Severity"]]
+
+if args.below5:
+    df = df[df["Age"] != "60+"]
+
+genotype_counts = df.groupby(["Time", "Strain"]).size().reset_index(name="Counts")
+
+# Calculate total counts per time period
+time_totals = genotype_counts.groupby("Time")["Counts"].sum().reset_index()
+time_totals.rename(columns={"Counts": "Total_Counts"}, inplace=True)
+
+# Merge totals back with genotype counts
+genotype_counts = genotype_counts.merge(time_totals, on="Time")
+
+# Calculate percentage for each strain
+genotype_counts["Percentage"] = (
+    genotype_counts["Counts"] / genotype_counts["Total_Counts"]
+)
+
+# Extract G1P8 percentages
+g1p8_percentages = genotype_counts[genotype_counts["Strain"] == "G1P8R1C1"][
+    ["Time", "Percentage"]
+].copy()
+
+print("G1P8 percentages by time:")
+print(g1p8_percentages.to_string(index=False))

--- a/scripts/get_infection_rate.py
+++ b/scripts/get_infection_rate.py
@@ -1,0 +1,73 @@
+import argparse
+import re
+import pandas as pd
+
+
+def strainName(strainIn):
+    s_types = [set() for i in range(4)]
+    for strain in strainIn:
+        pattern = r"G(\d+)P(\d+)A(\d+)B(\d+)"
+        match = re.match(pattern, strain)
+        for i, n in enumerate(match.groups()):
+            s_types[i].add(n)
+    newLabel = ""
+    for i, l in enumerate("GPRC"):
+        if len(s_types[i]) > 1:
+            newLabel += l + "[" + "+".join(sorted(s_types[i])) + "]"
+        else:
+            newLabel += l + list(s_types[i])[0]
+    return newLabel
+
+
+parser = argparse.ArgumentParser(description="Process input parameters.")
+
+parser.add_argument("datafile", type=str, help="Strain count file")
+args = parser.parse_args()
+
+datafile = args.datafile
+
+print("Processing file: {}".format(datafile))
+df = pd.read_csv(datafile)[
+    [
+        "id",
+        "CollectionTime",
+        "Age",
+        "Strain",
+        "Severity",
+        "InfectionTime",
+        "PopulationSize",
+    ]
+]
+
+df["InfectionTime"] = df["InfectionTime"].astype(int)
+df["Time"] = df["InfectionTime"]
+df["PopulationSize"] = df.groupby(["Time"])["PopulationSize"].transform("min")
+df["PopulationSize"] = df.groupby(["id", "Strain", "Time"])["PopulationSize"].transform(
+    "min"
+)
+
+df = (
+    df.groupby(["id", "Time", "Age", "PopulationSize"])
+    .agg({"Strain": strainName, "Severity": any})
+    .reset_index()
+)
+
+df = df[df["Severity"]]
+
+# Calculate infection counts by time
+infection_counts = df.groupby("Time").size().reset_index(name="Infection_Count")
+
+# Calculate mean population size by time
+mean_population = df.groupby("Time")["PopulationSize"].mean().reset_index()
+mean_population.rename(columns={"PopulationSize": "Mean_Population"}, inplace=True)
+
+# Merge counts and population data
+infection_rate_data = infection_counts.merge(mean_population, on="Time")
+
+# Calculate infection rate
+infection_rate_data["Infection_Rate"] = (
+    infection_rate_data["Infection_Count"] / infection_rate_data["Mean_Population"]
+)
+
+print("Infection rates by time:")
+print(infection_rate_data[["Time", "Infection_Rate"]].to_string(index=False))

--- a/scripts/get_number_of_strains.py
+++ b/scripts/get_number_of_strains.py
@@ -1,0 +1,68 @@
+import argparse
+import re
+import pandas as pd
+
+
+def strainName(strainIn):
+    s_types = [set() for i in range(4)]
+    for strain in strainIn:
+        pattern = r"G(\d+)P(\d+)A(\d+)B(\d+)"
+        match = re.match(pattern, strain)
+        for i, n in enumerate(match.groups()):
+            s_types[i].add(n)
+    newLabel = ""
+    for i, l in enumerate("GPRC"):
+        if len(s_types[i]) > 1:
+            newLabel += l + "[" + "+".join(sorted(s_types[i])) + "]"
+        else:
+            newLabel += l + list(s_types[i])[0]
+    return newLabel
+
+
+parser = argparse.ArgumentParser(description="Process input parameters.")
+
+parser.add_argument("datafile", type=str, help="Strain count file")
+parser.add_argument(
+    "--below5", action="store_true", help="use only incidences with age below 5"
+)
+parser.add_argument("--severe", action="store_true", help="use only severe incidences")
+args = parser.parse_args()
+
+datafile = args.datafile
+
+print("Processing file: {}".format(datafile))
+df = pd.read_csv(datafile)[
+    [
+        "id",
+        "CollectionTime",
+        "Age",
+        "Strain",
+        "Severity",
+        "InfectionTime",
+        "PopulationSize",
+    ]
+]
+
+df["InfectionTime"] = df["InfectionTime"].astype(int)
+df["Time"] = df["InfectionTime"]
+df["PopulationSize"] = df.groupby(["Time"])["PopulationSize"].transform("min")
+df["PopulationSize"] = df.groupby(["id", "Strain", "Time"])["PopulationSize"].transform(
+    "min"
+)
+
+if args.severe:
+    df = df[df["Severity"]]
+
+if args.below5:
+    df = df[df["Age"] != "60+"]
+
+genotype_counts = df.groupby(["Time", "Strain"]).size().reset_index(name="Counts")
+
+# Calculate number of unique strains per time period
+unique_strains_per_time = (
+    genotype_counts.groupby("Time")["Strain"].nunique().reset_index()
+)
+unique_strains_per_time.rename(columns={"Strain": "Unique_Strains"}, inplace=True)
+
+print("Number of unique strains by time:")
+print(unique_strains_per_time.to_string(index=False))

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -2,12 +2,12 @@ import rotasim as rs
 import sciris as sc
 import pytest
 
+
 def test_strainstats():
     # Test running sims
-    sc.heading('Test StrainStats analyzer')
-    sim = rs.Sim(N=5_000, timelimit=2, analyzers=rs.StrainStats())
+    sc.heading("Test StrainStats analyzer")
+    sim = rs.Sim(N=10_000, timelimit=4, analyzers=rs.StrainStats())
     events = sim.run()
-
 
     strains = sim.connectors.rota.pars.segment_combinations
 
@@ -16,10 +16,14 @@ def test_strainstats():
     for i in range(len(sim.results.strainstats.timevec)):
         prop_sum = 0
         for strain in strains:
-            prop_sum += sim.results.strainstats[f'{strain} proportion'][i]
-        assert pytest.approx(prop_sum, .001) == 1
+            prop_sum += sim.results.strainstats[f"{strain} proportion"][i]
+        assert pytest.approx(prop_sum, 0.001) == 1
 
-    df = sim.analyzers.strainstats.to_df()
-    plots = sim.results.strainstats.plot()
+    # df = sim.analyzers.strainstats.to_df()
+    # plots = sim.results.strainstats.plot()
+    print(sim.analyzers.strainstats.get_strain_proportions("(1, 8, 1, 1)"))
 
     return
+
+
+test_strainstats()


### PR DESCRIPTION
Adding scripts to get calibration data from output files:

I have added four scripts. 
1. get_g1p8_proportion.py: prints the proportion of G1P8 infections for each simulation year.
To run the script: `python get_g1p8_proportion.py <RESULTS FILE>`

When you run the simulation with `to_csv=True`, the results file will be written to `rota_strains_infected_all_<suffix based on parameters>.csv`

The script also has flags `-severe` and `-below5` to filter the data if needed.

The output will look as follows:

```
G1P8 percentages by time:
 Time  Percentage
    0    0.441695
    1    0.479855
    2    0.498644
    3    0.500662
    4    0.496727
    5    0.488660
    6    0.517733
    7    0.498100
    8    0.504821
    9    0.514141
   10    0.501238
   11    0.507978
   12    0.503243
   13    0.499752
   14    0.500511
   15    0.496487
   16    0.503617
   17    0.503465
   18    0.495866
   19    0.499611
```

2. get_number_of_strains.py
3. get_infection_rate.py
4. get_age_distribution_severe.py

Above scripts also can be run similar to the first example.

For calibration target 1: I also edited the existing analyzer that tracks the strain counts to add a helper function. For the other targets we need a separate analyzer that tracks strain incidence in a given period of time. I will work on that next. 