### PR TITLE
Fix #37: persist per-infant maternal titer (was redrawn every step)

### DIFF
--- a/rotasim/immunity.py
+++ b/rotasim/immunity.py
@@ -447,7 +447,15 @@ class RotaImmunityConnector(ss.Connector):
                             self._mat_rng = np.random.default_rng(int(self.sim.pars.rand_seed or 0) + 90210)
                         sigma = np.log(max(float(self.pars.maternal_titer_gsd), 1.0 + 1e-9))
                         med = max(float(self.pars.maternal_titer_median), 1e-9)
-                        t0[need] = med * np.exp(sigma * self._mat_rng.standard_normal(int(need.sum())))
+                        drawn = med * np.exp(sigma * self._mat_rng.standard_normal(int(need.sum())))
+                        # PERSIST each infant's initial titer (drawn once at birth) into the
+                        # state array. `.values` is a copy, so we must write back through the
+                        # Arr; otherwise maternal_titer0 stays NaN and is re-drawn every step,
+                        # giving each infant a fresh random titer daily (no coherent per-infant
+                        # decay). The population-mean curve is unaffected, but per-infant
+                        # heterogeneity in protection duration is lost. See issue #37.
+                        self.maternal_titer0[self.maternal_titer0.auids[need]] = drawn
+                        t0 = self.maternal_titer0.values  # refresh with the persisted draws
                     hl_years = self.pars.maternal_titer_half_life.years
                     titer = t0 * np.exp(-np.log(2) * agent_ages_years / hl_years)
                     th = np.power(np.maximum(titer, 0.0), float(self.pars.maternal_hill_slope))


### PR DESCRIPTION
## Fix #37 — persist the per-infant maternal titer

The titer maternal model (`maternal_immunity_model='titer'`) never persisted `maternal_titer0`. The draw was written into a **local copy** (`t0 = self.maternal_titer0.values`), so the state array stayed `NaN` and **every agent got a fresh random titer on every timestep**. Net effect:

- **Population-mean** maternal-protection-by-age curve: *unaffected* (titers re-drawn from the same log-normal each step, so the age-aggregated mean is statistically identical) — which is why it never showed up in the population-level fit.
- **Individual infants:** no coherent titer trajectory — protection was re-randomized daily instead of decaying from a fixed birth titer. This erases the between-infant heterogeneity in protection *duration* that is the whole point of the titer model, and can subtly reshape the spread of age-at-first-infection.

### The change (one spot, additive)
Write the draw back through the `Arr` so each infant draws **once** at birth and decays deterministically:

```python
drawn = med * np.exp(sigma * self._mat_rng.standard_normal(int(need.sum())))
self.maternal_titer0[self.maternal_titer0.auids[need]] = drawn   # persist
t0 = self.maternal_titer0.values                                  # refresh
```

Default (`'erlang'`) path is untouched.

### Test (3000-agent titer sim, ~6 months)
- **NaN titer among alive: 0 / 2000** (previously all `NaN`)
- **Persistence: 0 of 3021 agents** changed `titer0` across a mid→end re-check (previously resampled every step)
- titer0 median **19.9** vs target 20 ✓ (log-normal draw intact)

### ⚠️ This changes results — merge deliberately
Drawing once instead of every step **changes RNG consumption**, so simulated trajectories — and any calibrated posterior — will shift. Please **re-verify the MAL-ED fit** after merging; don't assume prior fits carry over. (For reference: a sibling diagnostic showed population maternal curves are largely unchanged, so the fit should re-converge nearby, but the individual-level dynamics — and the age-at-first-infection spread — are now genuinely active.)

Fixes #37.
